### PR TITLE
fixed PHP7.1 compatibility issue

### DIFF
--- a/lib/DateTime.php
+++ b/lib/DateTime.php
@@ -159,13 +159,13 @@ class DateTime extends \DateTime implements DateTimeInterface
 		return parent::setDate($year, $month, $day);
 	}
 
-	public function setISODate($year, $week , $day = 1)
+	public function setISODate($year, $week, $day = 1)
 	{
 		$this->flag_dirty();
 		return parent::setISODate($year, $week, $day);
 	}
 
-	public function setTime($hour, $minute, $second = 0)
+	public function setTime($hour, $minute, $second = null, $microseconds = null)
 	{
 		$this->flag_dirty();
 		return parent::setTime($hour, $minute, $second);


### PR DESCRIPTION
Warning: Declaration of ActiveRecord\DateTime::setTime($hour, $minute, $second = 0) should be compatible with DateTime::setTime($hour, $minute, $second = NULL, $microseconds = NULL)